### PR TITLE
Add resize method to connect-thumbs.js

### DIFF
--- a/lib/connect-thumbs.js
+++ b/lib/connect-thumbs.js
@@ -260,7 +260,8 @@ function modifyImage(options, callback) {
 
           gm(srcPath)
               .crop(rt.width, rt.height, rt.x, rt.y)
-              .resize(preset.width, preset.height || null)
+              .resize(preset.width, preset.height || null, "!")
+              .gravity('Center')
               .quality(preset.quality)
               .write(dstPath, callback);
 

--- a/lib/connect-thumbs.js
+++ b/lib/connect-thumbs.js
@@ -260,6 +260,7 @@ function modifyImage(options, callback) {
 
           gm(srcPath)
               .crop(rt.width, rt.height, rt.x, rt.y)
+              .resize(preset.width, preset.height || null)
               .quality(preset.quality)
               .write(dstPath, callback);
 


### PR DESCRIPTION
Add gm.resize option to SmartCrop.crop callback in connect-thumbs.js.

This function makes sure that the output image size is exactly what the preset specifies. If the preset is 300x520 then the resulting image is exactly 300x520. Without it SmartCrop.js process finds a matching size without resizing the image completely, resulting in a slightly larger image in the correct aspect ratio.
