### PR TITLE
Swallow upstream server errors and produce a 404

### DIFF
--- a/lib/connect-thumbs.js
+++ b/lib/connect-thumbs.js
@@ -110,7 +110,12 @@ exports = module.exports = function (opts) {
         }
 
         fileStream = fs.createWriteStream(filepath);
-        request.get(decodedImageURL).pipe(fileStream);
+        request.get(decodedImageURL).on('error', function (err){
+          //console.log(err);
+          res.writeHead(404);
+          res.end("Not Found!");
+          return resume(false);
+        }).pipe(fileStream);
 
         fileStream.on("close", function sendFileAfterTransform() {
 


### PR DESCRIPTION
When getting an image from an HTTP server the system should handle errors gracefully. This PR responds with a 404 when the upstream server is down or otherwise producing errors. A console.log message is commented out as a placeholder for future logging.
